### PR TITLE
fix typo in test-go.sh

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -11,7 +11,7 @@ cd "${OVN_KUBE_ROOT}"
 PKGS=$(go list -mod vendor -f '{{if len .TestGoFiles}} {{.ImportPath}} {{end}}' ${PKGS:-./cmd/... ./pkg/... ./hybrid-overlay/...} | xargs)
 
 if [[ "$1" == "focus" && "$2" != "" ]]; then
-    gingko_focus="-ginkgo.focus="${2}""
+    ginkgo_focus="-ginkgo.focus="${2}""
 fi
 
 TEST_REPORT_DIR=${TEST_REPORT_DIR:="./_artifacts"}


### PR DESCRIPTION
this typo makes test-go.sh ignore ginkgo focus setting.

